### PR TITLE
Add the .env file for localstack aws configuration to the remix example

### DIFF
--- a/examples/remix/.env
+++ b/examples/remix/.env
@@ -1,0 +1,8 @@
+# WARNING! This file is committed to git!
+# Don't put actual AWS credentials in here
+
+# These are the fake AWS credentials for use with localstack
+AWS_ACCESS_KEY_ID=test
+AWS_SECRET_ACCESS_KEY=test
+AWS_ACCOUNT_ID=000000000000
+AWS_REGION=eu-central-1

--- a/examples/remix/.gitignore
+++ b/examples/remix/.gitignore
@@ -3,4 +3,3 @@ node_modules
 /.cache
 /build
 /public/build
-.env


### PR DESCRIPTION
Wasn't included in the original PR because `npm create-remix` had .env gitignored.